### PR TITLE
Update zigtools release artifact file names to match Zig 0.15.0

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -89,7 +89,7 @@ impl ZigExtension {
             zed::Os::Windows => "zip",
         };
 
-        let asset_name: String = format!("zls-{}-{}-{}.{}", os, arch, release.version, extension);
+        let asset_name: String = format!("zls-{}-{}-{}.{}", arch, os, release.version, extension);
         let download_url = format!("https://builds.zigtools.org/{}", asset_name);
 
         let version_dir = format!("zls-{}", release.version);


### PR DESCRIPTION
Before: `zls-linux-x86_64-0.14.0.tar.xz`. 
After:  `zls-x86_64-linux-0.15.0.tar.xz`