### PR TITLE
Update tree-sitter-zig to latest version

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -12,4 +12,4 @@ language = "Zig"
 
 [grammars.zig]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-zig"
-commit = "eb7d58c2dc4fbeea4745019dee8df013034ae66b"
+commit = "6479aa13f32f701c383083d8b28360ebd682fb7d"


### PR DESCRIPTION
There were some infrastructure changes in the repo, but a couple of grammar changes:

- support for labeled switch statemnts
- fixed structure of arguments for function calls (allowing ia/aa motions)

Tested the updated version, everything is working, the now operations like cia in vim-mode also work.