### PR TITLE
Narrow tag of function declaration captures

### DIFF
--- a/languages/zig/highlights.scm
+++ b/languages/zig/highlights.scm
@@ -90,7 +90,7 @@
     member: (identifier) @function.call))
 
 (function_declaration
-  name: (identifier) @function)
+  name: (identifier) @function.definition)
 
 ; Modules
 


### PR DESCRIPTION
Following builtin python, we tag function declaration captures with `@function.definition` instead of `@function`. See https://github.com/zed-industries/zed/blob/e1a09e290c48fc02d07aaf2150856d77996414df/crates/languages/src/python/highlights.scm#L52.

This fixes highlighting for themes making the distinction between declarations and calls. One such theme is Alabaster, see https://github.com/tsimoshka/zed-theme-alabaster/blob/124750e2cab8a7fbfdaf26c7ccfc5fa0ba1d0541/themes/alabaster-color-theme.json#L242.