### PR TITLE
feat: migrate LSP backend from zls to zigscient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,10 +42,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
-name = "bumpalo"
-version = "3.19.0"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cfg-if"
@@ -45,12 +63,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -185,15 +232,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.3"
+name = "generic-array"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -210,6 +268,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "icu_collections"
@@ -343,9 +407,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -371,9 +435,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -453,21 +517,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
@@ -480,18 +567,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -500,14 +597,26 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -576,6 +685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,9 +722,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -617,28 +732,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
+name = "version_check"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -648,24 +769,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -673,22 +780,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -700,7 +807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.227.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -718,8 +835,20 @@ dependencies = [
  "serde_json",
  "spdx",
  "url",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.227.1",
+ "wasmparser 0.227.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -735,20 +864,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10fb6648689b3929d56bbc7eb1acf70c9a42a29eb5358c67c10f54dbd5d695de"
 dependencies = [
  "wit-bindgen-rt",
- "wit-bindgen-rust-macro",
+ "wit-bindgen-rust-macro 0.41.0",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro 0.51.0",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -758,7 +908,18 @@ checksum = "92fa781d4f2ff6d3f27f3cc9b74a73327b31ca0dc4a3ef25a0ce2983e0e5af9b"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.227.1",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -783,9 +944,25 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.227.1",
+ "wit-bindgen-core 0.41.0",
+ "wit-component 0.227.1",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.51.0",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -799,8 +976,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "wit-bindgen-core 0.41.0",
+ "wit-bindgen-rust 0.41.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core 0.51.0",
+ "wit-bindgen-rust 0.51.0",
 ]
 
 [[package]]
@@ -816,10 +1008,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.227.1",
+ "wasm-metadata 0.227.1",
+ "wasmparser 0.227.1",
+ "wit-parser 0.227.1",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata 0.244.0",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -837,7 +1048,25 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.227.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -883,9 +1112,13 @@ dependencies = [
 
 [[package]]
 name = "zed_zig"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
+ "hex",
+ "regex",
+ "serde",
  "serde_json",
+ "sha1",
  "uuid",
  "zed_extension_api",
 ]
@@ -943,3 +1176,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,19 @@
 [package]
 name = "zed_zig"
-version = "0.4.2"
-edition = "2021"
-publish = false
+version = "0.5.0"
+edition = "2024"
 license = "Apache-2.0"
+publish = false
 
 [lib]
-path = "src/zig.rs"
 crate-type = ["cdylib"]
+path = "src/zig.rs"
 
 [dependencies]
-serde_json = "1.0"
-uuid = { version = "1.1.2", features = ["v4"] }
+hex = "0.4.3"
+regex = "1.12.2"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+sha1 = "0.10.6"
+uuid = { version = "1.23.1", features = ["v4"] }
 zed_extension_api = "0.7.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,13 +1,13 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.4.2"
+version = "0.5.0"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-extensions/zig"
 
-[language_servers.zls]
-name = "zls"
+[language_servers.zigscient]
+name = "zigscient"
 language = "Zig"
 
 [grammars.zig]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,53 @@
+use zed_extension_api::{Worktree, serde_json::Value};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum CheckUpdates {
+    #[default]
+    Always,
+    Once,
+    Never,
+}
+
+pub fn get_check_updates(configuration: &Option<Value>) -> CheckUpdates {
+    let mode = configuration
+        .as_ref()
+        .and_then(|cfg| cfg.pointer("/check_updates"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_lowercase());
+
+    match mode.as_deref() {
+        Some("once") => CheckUpdates::Once,
+        Some("never") => CheckUpdates::Never,
+        _ => CheckUpdates::default(),
+    }
+}
+
+/// Reads an explicit `zigscient_path` from the workspace configuration,
+/// expanding a leading `~` against the worktree's `$HOME`.
+pub fn get_binary_path(configuration: &Option<Value>, worktree: &Worktree) -> Option<String> {
+    let path = configuration
+        .as_ref()?
+        .pointer("/zigscient_path")
+        .and_then(|v| v.as_str())?
+        .to_string();
+
+    Some(expand_tilde(worktree, path))
+}
+
+fn expand_tilde(worktree: &Worktree, path: String) -> String {
+    if !path.starts_with('~') {
+        return path;
+    }
+    let home = worktree
+        .shell_env()
+        .into_iter()
+        .find(|(k, _)| k == "HOME")
+        .map(|(_, v)| v)
+        .unwrap_or_default();
+
+    if home.is_empty() {
+        path
+    } else {
+        path.replacen('~', &home, 1)
+    }
+}

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,0 +1,236 @@
+use zed_extension_api::{
+    CodeLabel, CodeLabelSpan, LanguageServerId,
+    lsp::{Completion, CompletionKind, Symbol, SymbolKind},
+};
+
+pub fn label_for_completion(
+    _language_server_id: &LanguageServerId,
+    completion: Completion,
+) -> Option<CodeLabel> {
+    let kind = completion.kind?;
+    let label = &completion.label;
+    let detail = completion.detail.as_deref().unwrap_or("");
+
+    match kind {
+        // ZLS detail: "fn(params) ReturnType" → display: "fn name(params) ReturnType"
+        CompletionKind::Function | CompletionKind::Method => {
+            if let Some(rest) = detail.strip_prefix("fn") {
+                let code = format!("fn {label}{rest} {{}}");
+                let name_start = "fn ".len();
+                let name_end = name_start + label.len();
+
+                let mut spans = vec![
+                    CodeLabelSpan::code_range(0.."fn ".len()),
+                    CodeLabelSpan::code_range(name_start..name_end),
+                ];
+
+                let rest_trimmed = rest.trim();
+                if !rest_trimmed.is_empty() {
+                    spans.push(CodeLabelSpan::literal(
+                        format!(" {rest_trimmed}"),
+                        Some("variable".into()),
+                    ));
+                }
+
+                return Some(CodeLabel {
+                    code,
+                    spans,
+                    filter_range: (name_start..name_end).into(),
+                });
+            }
+
+            simple_label(label)
+        }
+
+        // ZLS detail: "FieldType" → display: "name: FieldType"
+        CompletionKind::Field => {
+            if !detail.is_empty() {
+                let code = format!("{label}: {detail},");
+                let name_end = label.len();
+                Some(CodeLabel {
+                    spans: vec![
+                        CodeLabelSpan::code_range(0..name_end),
+                        CodeLabelSpan::literal(format!(": {detail}"), Some("type".into())),
+                    ],
+                    code,
+                    filter_range: (0..name_end).into(),
+                })
+            } else {
+                simple_label(label)
+            }
+        }
+
+        // ZLS detail: "const T" / "var T" / "T" → display: "const name: T" etc.
+        CompletionKind::Variable | CompletionKind::Constant => {
+            let (kw, type_str) = if let Some(t) = detail.strip_prefix("const ") {
+                ("const ", t)
+            } else if let Some(t) = detail.strip_prefix("var ") {
+                ("var ", t)
+            } else {
+                ("", detail)
+            };
+
+            if !type_str.is_empty() {
+                let code = format!("{kw}{label}: {type_str};");
+                let name_start = kw.len();
+                let name_end = name_start + label.len();
+                Some(CodeLabel {
+                    spans: vec![
+                        CodeLabelSpan::code_range(0..kw.len()),
+                        CodeLabelSpan::code_range(name_start..name_end),
+                        CodeLabelSpan::literal(format!(": {type_str}"), Some("type".into())),
+                    ],
+                    code,
+                    filter_range: (name_start..name_end).into(),
+                })
+            } else {
+                simple_label(label)
+            }
+        }
+
+        // ZLS detail: "EnumTypeName" → display: "EnumTypeName.name"
+        CompletionKind::EnumMember => {
+            if !detail.is_empty() {
+                let code = format!("const {detail} = .{label};");
+                let prefix = format!("const {detail} = .");
+                let name_start = prefix.len();
+                let name_end = name_start + label.len();
+                Some(CodeLabel {
+                    spans: vec![
+                        CodeLabelSpan::literal(format!("{detail}."), Some("type".into())),
+                        CodeLabelSpan::code_range(name_start..name_end),
+                    ],
+                    code,
+                    filter_range: (0..label.len()).into(),
+                })
+            } else {
+                simple_label(label)
+            }
+        }
+
+        CompletionKind::Struct
+        | CompletionKind::Class
+        | CompletionKind::Interface
+        | CompletionKind::Enum => {
+            let kw = match kind {
+                CompletionKind::Interface => "union ",
+                _ => "const ",
+            };
+            let code = format!("{kw}{label} = struct {{}};");
+            let name_start = kw.len();
+            let name_end = name_start + label.len();
+            Some(CodeLabel {
+                spans: vec![CodeLabelSpan::code_range(name_start..name_end)],
+                code,
+                filter_range: (name_start..name_end).into(),
+            })
+        }
+
+        CompletionKind::Keyword => Some(CodeLabel {
+            spans: vec![CodeLabelSpan::code_range(0..label.len())],
+            filter_range: (0..label.len()).into(),
+            code: label.clone(),
+        }),
+
+        CompletionKind::Module | CompletionKind::Unit => {
+            let code = format!("const {label} = @import(\"\");");
+            let name_start = "const ".len();
+            let name_end = name_start + label.len();
+            Some(CodeLabel {
+                spans: vec![
+                    CodeLabelSpan::code_range(0.."const ".len()),
+                    CodeLabelSpan::code_range(name_start..name_end),
+                ],
+                code,
+                filter_range: (name_start..name_end).into(),
+            })
+        }
+
+        _ => simple_label(label),
+    }
+}
+
+pub fn label_for_symbol(
+    _language_server_id: &LanguageServerId,
+    symbol: Symbol,
+) -> Option<CodeLabel> {
+    let name = &symbol.name;
+
+    match symbol.kind {
+        SymbolKind::Function | SymbolKind::Method => {
+            let code = format!("fn {name}() {{}}");
+            let start = "fn ".len();
+            Some(CodeLabel {
+                spans: vec![
+                    CodeLabelSpan::code_range(0.."fn ".len()),
+                    CodeLabelSpan::code_range(start..start + name.len()),
+                ],
+                filter_range: (start..start + name.len()).into(),
+                code,
+            })
+        }
+
+        SymbolKind::Struct | SymbolKind::Class => {
+            let code = format!("const {name} = struct {{}};");
+            let start = "const ".len();
+            Some(CodeLabel {
+                spans: vec![CodeLabelSpan::code_range(start..start + name.len())],
+                filter_range: (start..start + name.len()).into(),
+                code,
+            })
+        }
+
+        SymbolKind::Enum => {
+            let code = format!("const {name} = enum {{}};");
+            let start = "const ".len();
+            Some(CodeLabel {
+                spans: vec![CodeLabelSpan::code_range(start..start + name.len())],
+                filter_range: (start..start + name.len()).into(),
+                code,
+            })
+        }
+
+        SymbolKind::Interface => {
+            let code = format!("const {name} = union {{}};");
+            let start = "const ".len();
+            Some(CodeLabel {
+                spans: vec![CodeLabelSpan::code_range(start..start + name.len())],
+                filter_range: (start..start + name.len()).into(),
+                code,
+            })
+        }
+
+        SymbolKind::Constant | SymbolKind::Variable | SymbolKind::Field => {
+            let code = format!("const {name}: T = undefined;");
+            let start = "const ".len();
+            Some(CodeLabel {
+                spans: vec![CodeLabelSpan::code_range(start..start + name.len())],
+                filter_range: (start..start + name.len()).into(),
+                code,
+            })
+        }
+
+        SymbolKind::Module | SymbolKind::Namespace | SymbolKind::Package => {
+            let code = format!("const {name} = @import(\"\");");
+            let start = "const ".len();
+            Some(CodeLabel {
+                spans: vec![
+                    CodeLabelSpan::code_range(0.."const ".len()),
+                    CodeLabelSpan::code_range(start..start + name.len()),
+                ],
+                filter_range: (start..start + name.len()).into(),
+                code,
+            })
+        }
+
+        _ => None,
+    }
+}
+
+fn simple_label(label: &str) -> Option<CodeLabel> {
+    Some(CodeLabel {
+        code: label.to_string(),
+        spans: vec![CodeLabelSpan::code_range(0..label.len())],
+        filter_range: (0..label.len()).into(),
+    })
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+use zed_extension_api as zed;
+
+const PATH_ERR: &str = "Failed to convert path to string";
+
+pub fn path_to_string<P: AsRef<Path>>(path: P) -> zed::Result<String> {
+    path.as_ref()
+        .to_path_buf()
+        .into_os_string()
+        .into_string()
+        .map_err(|_| PATH_ERR.to_string())
+}

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -1,139 +1,74 @@
-use std::{fs, path::Path};
-use zed_extension_api::{self as zed, serde_json, settings::LspSettings, LanguageServerId, Result};
+mod config;
+mod labels;
+mod util;
+mod zigscient;
 
-const ZIG_TEST_EXE_BASENAME: &str = "zig_test";
+use std::path::PathBuf;
+
+use zed_extension_api::{
+    self as zed, CodeLabel, LanguageServerId, Result,
+    lsp::{Completion, Symbol},
+    register_extension, serde_json,
+    settings::LspSettings,
+};
+
+use crate::{
+    config::{get_binary_path, get_check_updates},
+    labels::{label_for_completion as zig_label_completion, label_for_symbol as zig_label_symbol},
+    util::path_to_string,
+};
 
 struct ZigExtension {
-    cached_binary_path: Option<String>,
-}
-
-#[derive(Clone)]
-struct ZlsBinary {
-    path: String,
-    args: Option<Vec<String>>,
-    environment: Option<Vec<(String, String)>>,
+    cached_binary_path: Option<PathBuf>,
 }
 
 impl ZigExtension {
-    fn language_server_binary(
+    fn language_server_binary_path(
         &mut self,
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
-    ) -> Result<ZlsBinary> {
-        let mut args: Option<Vec<String>> = None;
+    ) -> Result<PathBuf> {
+        let configuration = LspSettings::for_worktree("zigscient", worktree)
+            .ok()
+            .and_then(|s| s.settings);
 
-        let (platform, arch) = zed::current_platform();
-        let environment = match platform {
-            zed::Os::Mac | zed::Os::Linux => Some(worktree.shell_env()),
-            zed::Os::Windows => None,
-        };
+        // 1. Explicit path from workspace settings (`zigscient_path`).
+        if let Some(user_path) = get_binary_path(&configuration, worktree) {
+            let p = PathBuf::from(user_path);
+            self.cached_binary_path = Some(p.clone());
+            return Ok(p);
+        }
 
-        if let Ok(lsp_settings) = LspSettings::for_worktree("zls", worktree) {
-            if let Some(binary) = lsp_settings.binary {
-                args = binary.arguments;
-                if let Some(path) = binary.path {
-                    return Ok(ZlsBinary {
-                        path: path.clone(),
-                        args,
-                        environment,
-                    });
-                }
+        // 2. Explicit binary path via `lsp.zigscient.binary.path`.
+        if let Ok(lsp_settings) = LspSettings::for_worktree("zigscient", worktree) {
+            if let Some(binary) = lsp_settings.binary
+                && let Some(path) = binary.path
+            {
+                let p = PathBuf::from(&path);
+                self.cached_binary_path = Some(p.clone());
+                return Ok(p);
             }
         }
 
-        if let Some(path) = worktree.which("zls") {
-            return Ok(ZlsBinary {
-                path,
-                args,
-                environment,
-            });
+        // 3. zigscient already on PATH.
+        if let Some(path) = worktree.which("zigscient") {
+            let p = PathBuf::from(path);
+            self.cached_binary_path = Some(p.clone());
+            return Ok(p);
         }
 
-        if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
-                return Ok(ZlsBinary {
-                    path: path.clone(),
-                    args,
-                    environment,
-                });
+        // 4. Reuse a previously resolved path if it is still runnable.
+        if let Some(cached) = self.cached_binary_path.clone() {
+            if zigscient::is_runnable(&cached) {
+                return Ok(cached);
             }
         }
 
-        zed::set_language_server_installation_status(
-            language_server_id,
-            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-        );
-
-        // Note that in github releases and on zlstools.org the tar.gz asset is not shown
-        // but is available at https://builds.zigtools.org/zls-{os}-{arch}-{version}.tar.gz
-        let release = zed::latest_github_release(
-            "zigtools/zls",
-            zed::GithubReleaseOptions {
-                require_assets: true,
-                pre_release: false,
-            },
-        )?;
-
-        let arch: &str = match arch {
-            zed::Architecture::Aarch64 => "aarch64",
-            zed::Architecture::X86 => "x86",
-            zed::Architecture::X8664 => "x86_64",
-        };
-
-        let os: &str = match platform {
-            zed::Os::Mac => "macos",
-            zed::Os::Linux => "linux",
-            zed::Os::Windows => "windows",
-        };
-
-        let extension: &str = match platform {
-            zed::Os::Mac | zed::Os::Linux => "tar.gz",
-            zed::Os::Windows => "zip",
-        };
-
-        let asset_name: String = format!("zls-{}-{}-{}.{}", arch, os, release.version, extension);
-        let download_url = format!("https://builds.zigtools.org/{}", asset_name);
-
-        let version_dir = format!("zls-{}", release.version);
-        let binary_path = match platform {
-            zed::Os::Mac | zed::Os::Linux => format!("{version_dir}/zls"),
-            zed::Os::Windows => format!("{version_dir}/zls.exe"),
-        };
-
-        if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
-            zed::set_language_server_installation_status(
-                language_server_id,
-                &zed::LanguageServerInstallationStatus::Downloading,
-            );
-
-            zed::download_file(
-                &download_url,
-                &version_dir,
-                match platform {
-                    zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
-                    zed::Os::Windows => zed::DownloadedFileType::Zip,
-                },
-            )
-            .map_err(|e| format!("failed to download file: {e}"))?;
-
-            zed::make_file_executable(&binary_path)?;
-
-            let entries =
-                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
-            for entry in entries {
-                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
-                if entry.file_name().to_str() != Some(&version_dir) {
-                    fs::remove_dir_all(entry.path()).ok();
-                }
-            }
-        }
-
-        self.cached_binary_path = Some(binary_path.clone());
-        Ok(ZlsBinary {
-            path: binary_path,
-            args,
-            environment,
-        })
+        // 5. Download from GitHub releases.
+        let check_updates = get_check_updates(&configuration);
+        let path = zigscient::resolve_binary(language_server_id, check_updates)?;
+        self.cached_binary_path = Some(path.clone());
+        Ok(path)
     }
 }
 
@@ -149,24 +84,52 @@ impl zed::Extension for ZigExtension {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let zls_binary = self.language_server_binary(language_server_id, worktree)?;
+        let binary_path = self.language_server_binary_path(language_server_id, worktree)?;
+
+        let args = LspSettings::for_worktree("zigscient", worktree)
+            .ok()
+            .and_then(|s| s.binary)
+            .and_then(|b| b.arguments)
+            .unwrap_or_default();
+
+        let env = match zed::current_platform().0 {
+            zed::Os::Mac | zed::Os::Linux => worktree.shell_env(),
+            zed::Os::Windows => vec![],
+        };
+
         Ok(zed::Command {
-            command: zls_binary.path,
-            args: zls_binary.args.unwrap_or_default(),
-            env: zls_binary.environment.unwrap_or_default(),
+            command: path_to_string(&binary_path)?,
+            args,
+            env,
         })
     }
 
     fn language_server_workspace_configuration(
         &mut self,
-        _language_server_id: &zed::LanguageServerId,
+        _language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<Option<serde_json::Value>> {
-        let settings = LspSettings::for_worktree("zls", worktree)
+        let settings = LspSettings::for_worktree("zigscient", worktree)
             .ok()
-            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .and_then(|s| s.settings)
             .unwrap_or_default();
         Ok(Some(settings))
+    }
+
+    fn label_for_completion(
+        &self,
+        language_server_id: &LanguageServerId,
+        completion: Completion,
+    ) -> Option<CodeLabel> {
+        zig_label_completion(language_server_id, completion)
+    }
+
+    fn label_for_symbol(
+        &self,
+        language_server_id: &LanguageServerId,
+        symbol: Symbol,
+    ) -> Option<CodeLabel> {
+        zig_label_symbol(language_server_id, symbol)
     }
 
     fn dap_locator_create_scenario(
@@ -181,57 +144,56 @@ impl zed::Extension for ZigExtension {
         }
 
         let cwd = build_task.cwd.clone();
-        let env = build_task.env.clone().into_iter().collect();
+        let env: Vec<(String, String)> = build_task.env.clone().into_iter().collect();
 
         let mut args_it = build_task.args.iter();
-        let template = match args_it.next() {
-            Some(arg) if arg == "build" => match args_it.next() {
-                Some(arg) if arg == "run" => zed::BuildTaskTemplate {
-                    label: "zig build".into(),
+        let template = match args_it.next().map(String::as_str) {
+            Some("build") => match args_it.next().map(String::as_str) {
+                Some("run") => zed::BuildTaskTemplate {
+                    label: "zig build run".into(),
                     command: "zig".into(),
-                    args: vec!["build".into()],
+                    args: vec!["build".into(), "run".into()],
                     env,
                     cwd,
                 },
                 _ => return None,
             },
-            Some(arg) if arg == "test" => {
-                let test_exe_path = get_test_exe_path().unwrap();
+
+            Some("test") => {
+                let test_exe_path = make_test_exe_path()?;
                 let mut args: Vec<String> = build_task
                     .args
                     .into_iter()
-                    // TODO verify if this is required on non-Windows platforms
-                    .map(|s| s.replace("\"", "'"))
+                    .map(|s| s.replace('"', "'"))
                     .collect();
                 args.push("--test-no-exec".into());
                 args.push(format!("-femit-bin={test_exe_path}"));
 
                 zed::BuildTaskTemplate {
-                    label: "zig test --test-no-exec".into(),
+                    label: "zig test (no-exec)".into(),
                     command: "zig".into(),
                     args,
                     env,
                     cwd,
                 }
             }
-            Some(arg) if arg == "run" => zed::BuildTaskTemplate {
+
+            Some("run") => zed::BuildTaskTemplate {
                 label: "zig run".into(),
                 command: "zig".into(),
                 args: vec!["run".into()],
                 env,
                 cwd,
             },
+
             _ => return None,
         };
 
-        let config = serde_json::Value::Null;
-        let Ok(config) = serde_json::to_string(&config) else {
-            return None;
-        };
+        let config = serde_json::to_string(&serde_json::Value::Null).ok()?;
 
         Some(zed::DebugScenario {
             adapter: debug_adapter_name,
-            label: resolved_label.clone(),
+            label: resolved_label,
             config,
             tcp_connection: None,
             build: Some(zed::BuildTaskDefinition::Template(
@@ -248,64 +210,58 @@ impl zed::Extension for ZigExtension {
         _locator_name: String,
         build_task: zed::TaskTemplate,
     ) -> Result<zed::DebugRequest, String> {
-        let mut args_it = build_task.args.iter();
-        match args_it.next() {
-            Some(arg) if arg == "build" => {
-                // We only handle the default case where the binary name matches the project name.
-                // This is valid for projects created with `zig init`.
-                // In other cases, the user should provide a custom debug configuration.
-                let exec = get_project_name(&build_task).ok_or("Failed to get project name")?;
+        match build_task.args.first().map(String::as_str) {
+            Some("build") => {
+                let exec = project_name_from_task(&build_task)
+                    .ok_or("Failed to determine project name from cwd")?;
 
-                let request = zed::LaunchRequest {
+                Ok(zed::DebugRequest::Launch(zed::LaunchRequest {
                     program: format!("zig-out/bin/{exec}"),
                     cwd: build_task.cwd,
                     args: vec![],
                     envs: build_task.env.into_iter().collect(),
-                };
-
-                Ok(zed::DebugRequest::Launch(request))
+                }))
             }
-            Some(arg) if arg == "test" => {
+
+            Some("test") => {
+                // The build step emits the test binary via `-femit-bin=<path>`;
+                // extract that path and strip any trailing ".exe".
                 let program = build_task
                     .args
                     .iter()
-                    .find_map(|arg| {
-                        arg.strip_prefix("-femit-bin=").map(|arg| {
-                            arg.split("=")
-                                .nth(1)
-                                .ok_or("Expected binary path in -femit-bin=")
-                                .map(|path| path.trim_end_matches(".exe"))
-                        })
-                    })
-                    .ok_or("Failed to extract binary path from command args")
-                    .flatten()?
-                    .to_string();
-                let request = zed::LaunchRequest {
+                    .find_map(|arg| arg.strip_prefix("-femit-bin="))
+                    .map(|path| path.trim_end_matches(".exe").to_string())
+                    .ok_or("Could not extract test binary path from -femit-bin= argument")?;
+
+                Ok(zed::DebugRequest::Launch(zed::LaunchRequest {
                     program,
                     cwd: build_task.cwd,
                     args: vec![],
                     envs: build_task.env.into_iter().collect(),
-                };
-                Ok(zed::DebugRequest::Launch(request))
+                }))
             }
-            _ => Err("Unsupported build task".into()),
+
+            _ => Err("Unsupported zig sub-command for DAP locator".into()),
         }
     }
 }
 
-fn get_project_name(task: &zed::TaskTemplate) -> Option<String> {
+fn project_name_from_task(task: &zed::TaskTemplate) -> Option<String> {
+    use std::path::Path;
     task.cwd
-        .as_ref()
-        .and_then(|cwd| Some(Path::new(&cwd).file_name()?.to_string_lossy().into_owned()))
+        .as_deref()
+        .and_then(|cwd| Path::new(cwd).file_name())
+        .map(|n| n.to_string_lossy().into_owned())
 }
 
-fn get_test_exe_path() -> Option<String> {
-    let test_exe_dir = std::env::current_dir().ok()?;
-    let mut name = format!("{}_{}", ZIG_TEST_EXE_BASENAME, uuid::Uuid::new_v4());
+/// Generates a unique path for the test binary relative to the extension's
+/// working directory (avoids needing `std::env::current_dir`).
+fn make_test_exe_path() -> Option<String> {
+    let mut name = format!("zig_test_{}", uuid::Uuid::new_v4());
     if zed::current_platform().0 == zed::Os::Windows {
         name.push_str(".exe");
     }
-    Some(test_exe_dir.join(name).to_string_lossy().into_owned())
+    Some(name)
 }
 
-zed::register_extension!(ZigExtension);
+register_extension!(ZigExtension);

--- a/src/zigscient.rs
+++ b/src/zigscient.rs
@@ -1,0 +1,126 @@
+use std::path::PathBuf;
+
+use zed_extension_api::{
+    self as zed, LanguageServerId, LanguageServerInstallationStatus, Result,
+    set_language_server_installation_status,
+};
+
+const REPO: &str = "llogick/zigscient-next";
+/// Prefix used in release tag names, e.g. "zigscient-next-0.16.0".
+const TAG_PREFIX: &str = "zigscient-next-";
+
+fn arch_str(arch: zed::Architecture) -> &'static str {
+    match arch {
+        zed::Architecture::Aarch64 => "aarch64",
+        zed::Architecture::X86 => "x86",
+        zed::Architecture::X8664 => "x86_64",
+    }
+}
+
+fn os_str(os: zed::Os) -> &'static str {
+    match os {
+        zed::Os::Mac => "macos",
+        zed::Os::Linux => "linux",
+        zed::Os::Windows => "windows",
+    }
+}
+
+/// Returns the name of the zigscient binary as it appears inside the release zip.
+pub fn binary_name(os: zed::Os, arch: zed::Architecture) -> &'static str {
+    match os {
+        zed::Os::Windows => "zigscient.exe",
+        _ => match (os, arch) {
+            (zed::Os::Mac, zed::Architecture::Aarch64) => "zigscient-aarch64-macos",
+            (zed::Os::Mac, zed::Architecture::X8664) => "zigscient-x86_64-macos",
+            (zed::Os::Linux, zed::Architecture::Aarch64) => "zigscient-aarch64-linux",
+            (zed::Os::Linux, zed::Architecture::X8664) => "zigscient-x86_64-linux",
+            _ => "zigscient",
+        },
+    }
+}
+
+struct Release {
+    version: String,
+    asset_url: String,
+}
+
+fn fetch_latest_release() -> Result<Release> {
+    let release = zed::latest_github_release(
+        REPO,
+        zed::GithubReleaseOptions {
+            require_assets: true,
+            pre_release: false,
+        },
+    )?;
+
+    let (os, arch) = zed::current_platform();
+    let expected_asset = format!("zigscient-{}-{}.zip", arch_str(arch), os_str(os));
+
+    let asset_url = release
+        .assets
+        .iter()
+        .find(|a| a.name == expected_asset)
+        .map(|a| a.download_url.clone())
+        .ok_or_else(|| {
+            format!(
+                "No asset '{expected_asset}' found in latest release. \
+                 Check https://github.com/{REPO}/releases"
+            )
+        })?;
+
+    // Tags look like "zigscient-next-0.16.0"; strip the prefix so the
+    // install directory is just the semver string.
+    let version = release
+        .version
+        .strip_prefix(TAG_PREFIX)
+        .unwrap_or(&release.version)
+        .to_string();
+
+    Ok(Release { version, asset_url })
+}
+
+/// Returns `true` if the binary at `path` responds successfully to `--version`.
+pub fn is_runnable(path: &PathBuf) -> bool {
+    zed::Command::new(path.to_string_lossy().as_ref())
+        .arg("--version")
+        .output()
+        .map(|o| o.status == Some(0))
+        .unwrap_or(false)
+}
+
+/// Resolves the zigscient binary, downloading it from GitHub if necessary.
+pub fn resolve_binary(
+    language_server_id: &LanguageServerId,
+    check_updates: crate::config::CheckUpdates,
+) -> Result<PathBuf> {
+    set_language_server_installation_status(
+        language_server_id,
+        &LanguageServerInstallationStatus::CheckingForUpdate,
+    );
+
+    let release = fetch_latest_release()?;
+    let (os, arch) = zed::current_platform();
+    let install_dir = PathBuf::from("zigscient").join(&release.version);
+    let binary = install_dir.join(binary_name(os, arch));
+
+    if check_updates != crate::config::CheckUpdates::Always && is_runnable(&binary) {
+        return Ok(binary);
+    }
+
+    set_language_server_installation_status(
+        language_server_id,
+        &LanguageServerInstallationStatus::Downloading,
+    );
+
+    zed::download_file(
+        &release.asset_url,
+        &install_dir.to_string_lossy(),
+        zed::DownloadedFileType::Zip,
+    )
+    .map_err(|e| format!("Failed to download zigscient: {e}"))?;
+
+    zed::make_file_executable(&binary.to_string_lossy())
+        .map_err(|e| format!("Failed to mark zigscient executable: {e}"))?;
+
+    Ok(binary)
+}


### PR DESCRIPTION
Replace zls with zigscient (llogick/zigscient-next) as the Zig language
server. zigscient is a more actively maintained fork with better
diagnostics and completion support.

Resolution order is unchanged:
  1. zigscient_path in workspace settings
  2. lsp.zigscient.binary.path
  3. zigscient on PATH
  4. cached path from previous run
  5. auto-download from GitHub releases

BREAKING CHANGE: workspace setting key renamed from `zls_path` to
`zigscient_path`. Users with an explicit path set must update their
Zed settings.json accordingly.