### PR TITLE
Add support for running doctest

### DIFF
--- a/languages/zig/runnables.scm
+++ b/languages/zig/runnables.scm
@@ -4,6 +4,10 @@
     (string_content) @name @ZIG_TEST_NAME)) @run
   (#set! tag zig-test))
 
+((test_declaration
+  (identifier) @name @ZIG_DOCTEST_NAME) @run
+  (#set! tag zig-doc-test))
+
 ; Tag main
 ((function_declaration
   name: (identifier) @_name) @run

--- a/languages/zig/tasks.json
+++ b/languages/zig/tasks.json
@@ -23,8 +23,19 @@
       "test",
       "$ZED_FILE",
       "--test-filter",
-      "\"$ZED_CUSTOM_ZIG_TEST_NAME\""
+      ".test.\"$ZED_CUSTOM_ZIG_TEST_NAME\""
     ],
     "tags": ["zig-test"]
+  },
+  {
+    "label": "zig test",
+    "command": "zig",
+    "args": [
+      "test",
+      "$ZED_FILE",
+      "--test-filter",
+      ".decltest.\"$ZED_CUSTOM_ZIG_DOCTEST_NAME\""
+    ],
+    "tags": ["zig-doc-test"]
   }
 ]


### PR DESCRIPTION
Zig's doctest are

> Test declarations named using an identifier (ref [spec][1])

This PR adds support for running doctest tests.

<img width="780" height="337" alt="Screenshot 2026-05-09 at 10 55 56" src="https://github.com/user-attachments/assets/834153c8-00ab-4f11-afe8-d21405b5142e" />

---

The PR also updates the extension's task to be more specific in which test it runs. Unfortunately, Zig doesn't let you specify the _exact_ test name to run (ie. the `^name$` exact). The `test-filter` flag only check the passed string against test's FQN, defined as `<namespace>.test.<name>` and `<namespace>.decltest.<name>`. Here I'm using the `.test.` and `.decltest.` substring as a semaphore.

[1]: https://ziglang.org/documentation/0.16.0/#Doctests